### PR TITLE
Support latest WD drive, updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/dist/
+/wdpassport_utils.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# WD My Passport Drive Hardware Encrypt Utility for Linux
+
+# WD My Passport Drive Hardware Encryption Utility for Linux
 
 A Linux command-line utility to lock, unlock, and manage the hardware encryption functionality of Western Digital My Passport external drives. Written in Python 3.
 
@@ -17,12 +18,10 @@ This tool was originally written by [0-duke](https://github.com/0-duke/wdpasspor
 
 ## Installing
 
-After downloading this project, you must install some additional Python packages:
+To install, use pip3 and the source code in this repository:
 ```
-pip3 install --user pyudev git+https://github.com/crypto-universe/py_sg
+sudo pip3 install git+https://github.com/JoshData/wdpassport-utils
 ```
-
-We're using a Python 3 port of the py_sg package.
 
 ## Usage
 
@@ -30,9 +29,8 @@ Run script as root or as a user that has permission to manage the device.
 
 When used without any arguments, the status of the drive is shown:
 ```
-$ sudo ./wdpassport-utils.py 
+$ sudo wdpassport-utils.py 
 [sudo] password for user: 
-WD Passport Ultra linux utility v0.1 by duke
 Device: /dev/sdc
 Security status: Unlocked
 Encryption type: Unknown (0x31)

--- a/README.md
+++ b/README.md
@@ -1,62 +1,75 @@
-# wdpassport-utils
-WD Passport Ultra Complete Utilities for Linux.
+# WD My Passport Drive Hardware Encrypt Utility for Linux
 
-<h1> Intro </h1>
+A Linux command-line utility to lock, unlock, and manage the hardware encryption functionality of Western Digital My Passport external drives. Written in Python 3.
 
-This script let you unlock, change password and erase Western Digital Passport devices on Linux platform. Modified to run on **python3**.
+WD My Passport drives support hardware encryption. New drives arrive in a passwordless state --- they can be used without locking or unlocking. After a password is set, drives become locked when they are unplugged and must be unlocked when they are plugged in to mount the volume and see its content.
 
-<h1> Install </h1>
+This utlity can:
 
-Install needed Python packages:
+* Show drive status.
+* Set and change the drive's password.
+* Unlock an encrypted drive, given the password.
+* Reset the drive in case of a lost password.
+
+Passwords given on the command line are converted into binary password data in a mechanism intended to be compatible with WD's unlock software that is used in Microsoft Windows.
+
+This tool was originally written by [0-duke](https://github.com/0-duke/wdpassport-utils) in 2015 based on reverse engineering research by [DanLukes](https://github.com/DanLukes) and an implementation by DanLukes and [KenMacD](https://github.com/KenMacD/wdpassport-utils). [crypto-universe](https://github.com/crypto-universe/wdpassport-utils) converted this project and the underlying SCSI interface library py_sg to Python 3. [JoshData](https://github.com/JoshData/wdpassport-utils) updated the library to work with the latest WD My Passport device.
+
+## Installing
+
+After downloading this project, you must install some additional Python packages:
 ```
 pip3 install --user pyudev git+https://github.com/crypto-universe/py_sg
 ```
 
-Or follow the instructions at https://github.com/crypto-universe/py_sg.
+We're using a Python 3 port of the py_sg package.
 
-<h1> Usage </h1>
+## Usage
 
-Run script as root.
+Run script as root or as a user that has permission to manage the device.
 
-When used without any arguments, the status of the drive is shown.
+When used without any arguments, the status of the drive is shown:
+```
+$ sudo ./wdpassport-utils.py 
+[sudo] password for user: 
+WD Passport Ultra linux utility v0.1 by duke
+Device: /dev/sdc
+Security status: Unlocked
+Encryption type: Unknown (0x31)
+```
 
 There are few options:
+
+```
+-u, --unlock          Unlock
+```
+Unlock a locked drive. You will be asked to enter the unlock password. If everything is fine device will be unlocked. (To lock a drive, unplug it.)
+
+```
+-m, --mount           Enable mount point for an unlocked device
+```
+After unlock, your operating system may still think that your device is a strange thing attached to its USB port and doesn't know how to manage it. This option forces the operating system to rescan the device and handle it as a normal external USB harddrive. This flag can be combined with `-u`.
+
+```
+-c, --change_passwd   Set, change, or remove password protection
+```
+Set a password on a new drive, change the password, or remove the password (so that it does not need to be unlocked to use). To remove a password, leave the new password empty.
+
+```
+-e, --erase           Erase/reset device
+```
+Erase (reset) the drive. This will remove the internal key associated to you password and all your data will be unaccessible. You will also lose your partition table and you will need to create a new one (you can use fdisk and mkfs or other utilities to prepare and format the drive).
+
+```
+-d DEVICE, --device DEVICE  Device path (ex. /dev/sdb). Optional.
+```
+This tool will try to auto-detect the device path of your WD My Passport device. If you have more than one device, or if auto-detection fails, you can manually specify the device path, e.g. as `/dev/sdb`.
+
 ```
 -h, --help            show this help message and exit
 ```
 Lists all possible arguments.
 
-```
--u, --unlock          Unlock
-```
-You will be asked to enter the unlock password. If everything is fine device will be unlocked.
-
-```
--m, --mount           Enable mount point for an unlocked device
-```
-After unlock, your operating system still thinks that your device is a strange thing attached to his usb port and he don't know how to manage. You need this option to force the O.S. to rescan the device and handle it as a normal external usb harddrive.
-
-```
--c, --change_passwd   Change (or disable) password
-```
-This option let you to encrypt your device, remove password protection and change your current password.
-If device is "without lock" and you want it to be password protect leave the "OLD password" field empty and choose insert the new password.
-If the device is password protected and you want to be as a normal unencrypted device, inser the old password and leave the "NEW password" field empty.
-If you only want to change password do it as usual.
-
-```
--e, --erase           Secure erase device
-```
-"Erase" the device. This will remove the internal key associated to you password and all your data will be unaccessible. You will also lose your partition table and you will need to create a new one (you can use fdisk and mkfs).
-
-```
--d DEVICE, --device DEVICE  Force device path (ex. /dev/sdb). Usually you don't need this option.
-```
-The script will try to auto detect the current device path of your WD Passport device.
-If something is wrong or you want to manually specify the device path yourself you can use this option.
-
 <h1>Disclaimer</h1>
-I based my research on Dan Lukes (FreeBSD version) and [KenMacD (very simple unlocker)](https://github.com/KenMacD/wdpassport-utils/blob/master/WD_Encryption_API.txt) works. 
-I'm in no way sponsored by or connected with Western Digital.
-Use any of the information contained in this repository at your own risk. I accept no
-responsibility.
+
+Use the tool and any of the information contained in this repository at your own risk. The tool was developed without any official documenation from Western Digital on how to manage the drive using its raw SCSI interface. We accept no responsibility.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Or follow the instructions at https://github.com/crypto-universe/py_sg.
 
 <h1> Usage </h1>
 
-Run script as root. 
+Run script as root.
+
+When used without any arguments, the status of the drive is shown.
 
 There are few options:
 ```
@@ -24,10 +26,6 @@ There are few options:
 ```
 Lists all possible arguments.
 
-```
--s, --status          Check device status and encryption type
-```
-Get device encryption status and cipher suites used.
 ```
 -u, --unlock          Unlock
 ```
@@ -58,7 +56,7 @@ The script will try to auto detect the current device path of your WD Passport d
 If something is wrong or you want to manually specify the device path yourself you can use this option.
 
 <h1>Disclaimer</h1>
-I based my research on Dan Lukes (FreeBSD version) and KenMacD (very simple unlocker) works. 
+I based my research on Dan Lukes (FreeBSD version) and [KenMacD (very simple unlocker)](https://github.com/KenMacD/wdpassport-utils/blob/master/WD_Encryption_API.txt) works. 
 I'm in no way sponsored by or connected with Western Digital.
 Use any of the information contained in this repository at your own risk. I accept no
 responsibility.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ WD Passport Ultra Complete Utilities for Linux.
 
 <h1> Intro </h1>
 
-This script let you unlock, change password and erase Western Digital Passport devices on Linux platform. 
+This script let you unlock, change password and erase Western Digital Passport devices on Linux platform. Modified to run on **python3**
 
 <h1> Install </h1>
 
@@ -11,8 +11,17 @@ In order to run this script you need to install "lsscsi" command and "py_sg" lib
 
 For example on Ubuntu you can install the missing dependancies with
 ```
-sudo apt-get install python-pip python-dev lsscsi
-sudo pip install py_sg
+sudo apt-get install python3-pip python3-dev lsscsi
+```
+
+For Fedora these are dependancies:
+```
+sudo dnf install python3-pip python3-devel lsscsi
+```
+
+Now you need to get py_sg for python3. Clone the repo using command below and follow installation guide from README.md
+```
+git clone git@github.com:crypto-universe/py_sg.git
 ```
 
 <h1> Usage </h1>

--- a/README.md
+++ b/README.md
@@ -3,26 +3,16 @@ WD Passport Ultra Complete Utilities for Linux.
 
 <h1> Intro </h1>
 
-This script let you unlock, change password and erase Western Digital Passport devices on Linux platform. Modified to run on **python3**
+This script let you unlock, change password and erase Western Digital Passport devices on Linux platform. Modified to run on **python3**.
 
 <h1> Install </h1>
 
-In order to run this script you need to install "lsscsi" command and "py_sg" library. 
-
-For example on Ubuntu you can install the missing dependancies with
+Install needed Python packages:
 ```
-sudo apt-get install python3-pip python3-dev lsscsi
+pip3 install --user pyudev git+https://github.com/crypto-universe/py_sg
 ```
 
-For Fedora these are dependancies:
-```
-sudo dnf install python3-pip python3-devel lsscsi
-```
-
-Now you need to get py_sg for python3. Clone the repo using command below and follow installation guide from README.md
-```
-git clone git@github.com:crypto-universe/py_sg.git
-```
+Or follow the instructions at https://github.com/crypto-universe/py_sg.
 
 <h1> Usage </h1>
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@ This tool was originally written by [0-duke](https://github.com/0-duke/wdpasspor
 
 ## Installing
 
-To install, use pip3 and the source code in this repository:
+You'll need the Python 3 development headers to install this tool. On Ubuntu run:
+
+```
+sudo apt install python3-dev
+```
+
+On other Linux distributions you may need a different command.
+
+Then use pip3 to install the source code in this repository:
 ```
 sudo pip3 install git+https://github.com/JoshData/wdpassport-utils
 ```

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+
+from setuptools import setup
+
+setup(name='wdpassport_utils',
+      version='0.2',
+      description='WD My Passport Drive Hardware Encryption Utility for Linux',
+      url='https://github.com/JoshData/wdpassport-utils',
+      author='0-duke, crypto-universe, JoshData',
+      author_email='jt@occams.info',
+      license='GPLv2',
+      install_requires=[
+        'pyudev',
+        'py_sg @ git+https://github.com/crypto-universe/py_sg',
+      ],
+      scripts=['wdpassport-utils.py'],
+      )

--- a/wdpassport-utils.py
+++ b/wdpassport-utils.py
@@ -33,11 +33,6 @@ def question(str):
 def title(str):
 	return "\033[93m" + str + "\033[0m"
 
-### Return if the current user is root
-def is_root_user():
-	if os.geteuid() != 0: return False
-	else: return True
-
 ## Convert an integer to his human-readable secure status
 def sec_status_to_str(security_status):
 	if security_status == 0x00:
@@ -379,10 +374,6 @@ def main(argv):
 	parser.add_argument("-d", "--device", dest="device", required=False, help="Force device path (ex. /dev/sdb). Usually you don't need this option.")
 
 	args = parser.parse_args()
-	
-	if not is_root_user():
-		print(fail("You need to have root privileges to run this script."))
-		sys.exit(1)
 	
 	if len(sys.argv) == 1:
 		args.status = True

--- a/wdpassport-utils.py
+++ b/wdpassport-utils.py
@@ -32,9 +32,6 @@ def success(str):
 def question(str):
 	return "\033[94m" + "[+]" + "\033[0m" + " " + str
 
-def title(str):
-	return "\033[93m" + str + "\033[0m"
-
 ## Convert an integer to his human-readable secure status
 def sec_status_to_str(security_status):
 	if security_status == 0x00:
@@ -375,7 +372,6 @@ def enable_mount(device):
 ## Main function, get parameters and manage operations
 def main(argv): 
 	global dev
-	print(title("WD Passport Ultra linux utility v0.1 by duke"))
 	parser = argparse.ArgumentParser()
 	parser.add_argument("-u", "--unlock", required=False, action="store_true", help="Unlock")
 	parser.add_argument("-m", "--mount", required=False, action="store_true", help="Enable mount point for an unlocked device")

--- a/wdpassport-utils.py
+++ b/wdpassport-utils.py
@@ -91,7 +91,7 @@ def read_handy_store(page):
 	for c in htonl(page):
 		cdb[i] = c
 		i+=1
-	data = py_sg.read(dev, _scsi_pack_cdb(cdb), BLOCK_SIZE)
+	data = py_sg.read_as_bin_str(dev, _scsi_pack_cdb(cdb), BLOCK_SIZE)
 	return data
 
 ## Calculate checksum on the returned data
@@ -124,7 +124,7 @@ def hsb_checksum(data):
 ##
 def get_encryption_status():
 	cdb = [0xC0, 0x45, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x30, 0x00]
-	data = py_sg.read(dev, _scsi_pack_cdb(cdb), BLOCK_SIZE)
+	data = py_sg.read_as_bin_str(dev, _scsi_pack_cdb(cdb), BLOCK_SIZE)
 	if data[0] != 0x45:
 		print(fail("Wrong encryption status signature %s" % hex(data[0])))
 		sys.exit(1)


### PR DESCRIPTION
Hey @0-duke. Thanks for your work to create this utility. I bought a new WD drive yesterday and was grateful that a tool existed to unlock the drive from Linux.

I had to make some modifications, though --- the drive reported it was using a new cipher (0x31) for which there was no known key length. But, luckily, the drive reports the key length for the active cipher, so I was able to use the information from the drive to get it to work. While I was there, I made a little afternoon project out of updating the code, replacing `subprocess` (which is prone to security vulnerabilities) with calls to `pyudev`, and some other things I think are improvements. In this PR, I'm also slurping in a few commits from @crypto-universe who made some changes to port the code (and the py_sg library!) to Python 3.

Are you still interested in maintaining this project? If so, I'd love to get these changes merged so I'm not maintaining a fork. If not, let me know --- I totally understand what it's like to have folks showing up out of the blue in repositories that you've moved on from long ago.