### PR TITLE
Filter out non hard disks from device search

### DIFF
--- a/wdpassport-utils.py
+++ b/wdpassport-utils.py
@@ -394,6 +394,10 @@ def main(argv):
 	passport_devices = []
 	context = pyudev.Context()
 	for disk_device in context.list_devices(subsystem='block', DEVTYPE='disk'):
+		# Skip non hard disks
+		if not disk_device.device_node.startswith('/dev/sd'):
+			continue
+
 		# If -d is used, filter devices.
 		if args.device and disk_device.device_node != args.device:
 			continue


### PR DESCRIPTION
Add a check to filter out non hard disks.

Some devices might mount CDROMs (/dev/srX) containing `WD-Unlock` tool used on Windows systems to decrypt the drive. These have the same `ID_SERIAL` value and will show up in the results as a different device.

Script wrongly tells me I have multiple devices and this check fixes that.